### PR TITLE
Handle last names beginning with Mac

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,9 +1,9 @@
 function getUserInput() {
-    let firstName = document.getElementById('FirstName').value;
-    let lastName = document.getElementById('LastName').value;
+    let firstName = document.getElementById('FirstName').value.toUpperCase();
+    let lastName = document.getElementById('LastName').value.toUpperCase();
     let dateOfBirth = document.getElementById('DatePicker').value;
 
-    let first = lastName.slice(0, 5);
+    let first = lastName.slice(0, 3) == 'MAC' ? 'MC'.concat(lastName.slice(3,6)) : lastName.slice(0, 5);
     if (first.length < 5) {
         first = first.padEnd(5, '9');
     }


### PR DESCRIPTION
As described in #3 :

> Any surname starting with Mac should be handled as if the "a" weren't there. This is meant to remove issues with spelling of Mac vs Mc, but applies to any surname that happens to begin with those three letters. Examples:
> 
>- McDonald: MCDON
>- MacDonald: MCDON
>- Macintosh: MCINT
>- less intuitively, Macedo (portuguese surname, unrelated with the "Mac/Mc" prefix): MCEDO

